### PR TITLE
Ex 5: Feature/endpoints delete

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,11 +105,15 @@ As rotas abaixo retornam null caso não haja cadastro com id solicitado.
 - GET ```/visitantes/:id```: Obtém a lista completa de visitantes.
 
 ### DELETE
-- DELETE ```/livro/{id}```: Deleta um livro.
-- DELETE ```/membros/{id}```: Deleta um membro.
-- DELETE ```/empréstimos/{id}```: Deleta um empréstimo.
-- DELETE ```/bibliotecarios/{id}```: Deleta um bibliotecário.
-- DELETE ```/visitantes/{id}```: Deleta um visitante.
+Todas as rotas retornam true quando a deleção é concluída com sucesso, 
+caso não exista o registro com o id informado retornará um erro.
+- DELETE ```/empréstimos/:id```: Deleta um empréstimo.
+- DELETE ```/visitantes/:id```: Deleta um visitante.
+
+As rotas abaixo só permitem a deleção caso não haja vinculo com a tabela empréstimo
+- DELETE ```/livro/:id```: Deleta um livro.
+- DELETE ```/membros/:id```: Deleta um membro.
+- DELETE ```/bibliotecarios/:id```: Deleta um bibliotecário.
 
 ### UPDATE
 - PUT ```/livro/{id}```: Atualiza as informações de um livro.
@@ -142,8 +146,8 @@ Essas queries utilizam JPQL ou Native Queries. <br/>
 - [ ] [Exercício 1 - Entidades do projeto](#-m1s09-ex-1---entidades-do-projeto)
 - [x] [Exercício 2 - MER](#-m1s09-ex-2---mer)
 - [x] [Exercício 3 - Endpoints CREATE](#-m1s09-ex-3---endpoints-create)
-- [X] [Exercício 4 - Endpoints READ](#-m1s09-ex-4---endpoints-read)
-- [ ] [Exercício 5 - Endpoints DELETE](#-m1s09-ex-5---endpoints-delete)
+- [x] [Exercício 4 - Endpoints READ](#-m1s09-ex-4---endpoints-read)
+- [x] [Exercício 5 - Endpoints DELETE](#-m1s09-ex-5---endpoints-delete)
 - [ ] [Exercício 6 - Queries UPDATE](#-m1s09-ex-6---queries-update)
 - [ ] [Exercício 7 - Endpoints UPDATE](#-m1s09-ex-7---endpoints-update)
 - [ ] [Exercício 8 - Scripts de criação de tabelas](#-m1s09-ex-8---scripts-de-criação-de-tabelas)

--- a/src/main/java/com/senai/biblioteca/controller/BibliotecarioController.java
+++ b/src/main/java/com/senai/biblioteca/controller/BibliotecarioController.java
@@ -28,4 +28,9 @@ public class BibliotecarioController {
     public Optional<BibliotecarioEntity> buscarPorId(@PathVariable Long id) {
         return bibliotecarioService.buscarPorId(id);
     }
+
+    @DeleteMapping("{id}")
+    public boolean deletarBibliotecario(@PathVariable Long id) {
+        return bibliotecarioService.deletarBibliotecario(id);
+    }
 }

--- a/src/main/java/com/senai/biblioteca/controller/EmprestimoController.java
+++ b/src/main/java/com/senai/biblioteca/controller/EmprestimoController.java
@@ -28,4 +28,9 @@ public class EmprestimoController {
     public Optional<EmprestimoEntity> buscarPorId(@PathVariable Long id) {
         return emprestimoService.buscarPorId(id);
     }
+
+    @DeleteMapping("{id}")
+    public boolean deletarEmprestimo(@PathVariable Long id) {
+        return emprestimoService.deletarEmprestimo(id);
+    }
 }

--- a/src/main/java/com/senai/biblioteca/controller/LivroController.java
+++ b/src/main/java/com/senai/biblioteca/controller/LivroController.java
@@ -28,4 +28,9 @@ public class LivroController {
     public Optional<LivroEntity> buscarPorId(@PathVariable Long id) {
         return livroService.buscarPorId(id);
     }
+
+    @DeleteMapping("{id}")
+    public boolean deletarLivro(@PathVariable Long id) {
+        return livroService.deletarLivro(id);
+    }
 }

--- a/src/main/java/com/senai/biblioteca/controller/MembroController.java
+++ b/src/main/java/com/senai/biblioteca/controller/MembroController.java
@@ -28,4 +28,9 @@ public class MembroController {
     public Optional<MembroEntity> buscarPorId(@PathVariable Long id) {
         return membroService.buscarPorId(id);
     }
+
+    @DeleteMapping("{id}")
+    public boolean deletarMembro(@PathVariable Long id) {
+        return membroService.deletarMembro(id);
+    }
 }

--- a/src/main/java/com/senai/biblioteca/controller/VisitanteController.java
+++ b/src/main/java/com/senai/biblioteca/controller/VisitanteController.java
@@ -28,4 +28,9 @@ public class VisitanteController {
     public Optional<VisitanteEntity> buscarPorId(@PathVariable Long id) {
         return visitanteService.buscarPorId(id);
     }
+
+    @DeleteMapping("{id}")
+    public boolean deletarVisitante(@PathVariable Long id) {
+        return visitanteService.deletarVisitante(id);
+    }
 }

--- a/src/main/java/com/senai/biblioteca/repository/BibliotecarioRepository.java
+++ b/src/main/java/com/senai/biblioteca/repository/BibliotecarioRepository.java
@@ -2,8 +2,11 @@ package com.senai.biblioteca.repository;
 
 import com.senai.biblioteca.entities.BibliotecarioEntity;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
 import org.springframework.stereotype.Repository;
 
 @Repository
 public interface BibliotecarioRepository extends JpaRepository<BibliotecarioEntity, Long> {
+    @Query(value = "SELECT COUNT(*) FROM emprestimos WHERE id_bibliotecario = :id", nativeQuery = true)
+    int countVinculos(Long id);
 }

--- a/src/main/java/com/senai/biblioteca/repository/LivroRepository.java
+++ b/src/main/java/com/senai/biblioteca/repository/LivroRepository.java
@@ -2,8 +2,11 @@ package com.senai.biblioteca.repository;
 
 import com.senai.biblioteca.entities.LivroEntity;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
 import org.springframework.stereotype.Repository;
 
 @Repository
 public interface LivroRepository extends JpaRepository<LivroEntity, Long> {
+    @Query(value = "SELECT COUNT(*) FROM emprestimos WHERE id_livro = :id", nativeQuery = true)
+    int countVinculos(Long id);
 }

--- a/src/main/java/com/senai/biblioteca/repository/MembroRepository.java
+++ b/src/main/java/com/senai/biblioteca/repository/MembroRepository.java
@@ -2,8 +2,11 @@ package com.senai.biblioteca.repository;
 
 import com.senai.biblioteca.entities.MembroEntity;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
 import org.springframework.stereotype.Repository;
 
 @Repository
 public interface MembroRepository extends JpaRepository<MembroEntity, Long> {
+    @Query(value = "SELECT COUNT(*) FROM emprestimos WHERE id_membro = :id", nativeQuery = true)
+    int countVinculos(Long id);
 }

--- a/src/main/java/com/senai/biblioteca/service/BibliotecarioService.java
+++ b/src/main/java/com/senai/biblioteca/service/BibliotecarioService.java
@@ -2,9 +2,12 @@ package com.senai.biblioteca.service;
 
 import com.senai.biblioteca.entities.BibliotecarioEntity;
 import com.senai.biblioteca.repository.BibliotecarioRepository;
+import jakarta.persistence.EntityManager;
 import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
 
+import javax.management.Query;
 import java.util.List;
 import java.util.Optional;
 
@@ -26,6 +29,21 @@ public class BibliotecarioService {
 
     public Optional<BibliotecarioEntity> buscarPorId(Long id) {
         return bibliotecarioRepository.findById(id);
+    }
+
+    public boolean deletarBibliotecario(Long id) {
+        boolean ahVinculos = bibliotecarioRepository.countVinculos(id) > 0;
+        if (buscarPorId(id).isEmpty()) {
+            throw new IllegalArgumentException("Bibliotecário com o ID " + id + " não encontrado.");
+        }
+        if (ahVinculos){
+            throw new IllegalStateException(
+                    "O bibliotecário está vinculado a um empréstimo e não pode ser excluído." +
+                    "Delete todos os empréstimos deste bibliotecário antes de deleta-lo."
+            );
+        }
+        bibliotecarioRepository.deleteById(id);
+        return true;
     }
 
     private boolean validar(BibliotecarioEntity bibliotecario) throws Exception {

--- a/src/main/java/com/senai/biblioteca/service/EmprestimoService.java
+++ b/src/main/java/com/senai/biblioteca/service/EmprestimoService.java
@@ -30,6 +30,14 @@ public class EmprestimoService {
         return emprestimoRepository.findById(id);
     }
 
+    public boolean deletarEmprestimo(Long id) {
+        if (buscarPorId(id).isEmpty()) {
+            throw new IllegalArgumentException("Empréstimo com o ID " + id + " não encontrado.");
+        }
+        emprestimoRepository.deleteById(id);
+        return true;
+    }
+
     private boolean validar(EmprestimoEntity emprestimo) throws Exception {
         if(emprestimo.getDataEmprestimo() == null || ehDataInvalida(emprestimo.getDataEmprestimo())){
             throw new Exception("Data deve estar no formato: DD/MM/AAAA.");

--- a/src/main/java/com/senai/biblioteca/service/LivroService.java
+++ b/src/main/java/com/senai/biblioteca/service/LivroService.java
@@ -29,6 +29,21 @@ public class LivroService {
         return livroRepository.findById(id);
     }
 
+    public boolean deletarLivro(Long id) {
+        boolean ahVinculos = livroRepository.countVinculos(id) > 0;
+        if (buscarPorId(id).isEmpty()) {
+            throw new IllegalArgumentException("Livro com o ID " + id + " não encontrado.");
+        }
+        if (ahVinculos){
+            throw new IllegalStateException(
+                    "O Livro está vinculado a um empréstimo e não pode ser excluído." +
+                    "Delete todos os empréstimos deste livro antes de deleta-lo."
+            );
+        }
+        livroRepository.deleteById(id);
+        return true;
+    }
+
     private boolean validar(LivroEntity livro) throws Exception {
         if(
                 livro.getTitulo() == null ||

--- a/src/main/java/com/senai/biblioteca/service/MembroService.java
+++ b/src/main/java/com/senai/biblioteca/service/MembroService.java
@@ -28,6 +28,21 @@ public class MembroService {
         return membroRepository.findById(id);
     }
 
+    public boolean deletarMembro(Long id) {
+        boolean ahVinculos = membroRepository.countVinculos(id) > 0;
+        if (buscarPorId(id).isEmpty()) {
+            throw new IllegalArgumentException("Membro com o ID " + id + " não encontrado.");
+        }
+        if (ahVinculos){
+            throw new IllegalStateException(
+                    "O membro está vinculado a um empréstimo e não pode ser excluído." +
+                    "Delete todos os empréstimos deste membro antes de deleta-lo."
+            );
+        }
+        membroRepository.deleteById(id);
+        return true;
+    }
+
     private boolean validar(MembroEntity membro) throws Exception {
         if(
                 membro.getNome() == null ||

--- a/src/main/java/com/senai/biblioteca/service/VisitanteService.java
+++ b/src/main/java/com/senai/biblioteca/service/VisitanteService.java
@@ -28,6 +28,14 @@ public class VisitanteService {
         return visitanteRepository.findById(id);
     }
 
+    public boolean deletarVisitante(Long id) {
+        if (buscarPorId(id).isEmpty()) {
+            throw new IllegalArgumentException("Visitante com o ID " + id + " não encontrado.");
+        }
+        visitanteRepository.deleteById(id);
+        return true;
+    }
+
     private boolean validar(VisitanteEntity visitante) throws Exception {
         if(
                 visitante.getNome() == null ||


### PR DESCRIPTION
# Exercício 5
Essa branch implementa a deleção todas as entidades, sendo possível deletar apenas o item com id específicado.
As entidades livro, membro e biblíotecario só são deletadas se não houver vínculo com a tabela emprestimo.

> Segue abaixo descritivo do exercício 5.

Cria os endpoints DELETE para cada uma das entidades.
Se uma tabela tem um relacionamento, ela deve poder ser deletada se o objeto relacionado for deletado primeiro.
Os caminhos devem ser os mesmo do exercício CREATE, mas devem ter métodos HTTP diferentes.
